### PR TITLE
Shard mecab instane and pykakasi support

### DIFF
--- a/furigana/furigana.py
+++ b/furigana/furigana.py
@@ -125,8 +125,9 @@ def split_furigana(text, mecab=None, kana2hiragana=None):
         if origin != "" and any(is_kanji(_) for _ in origin):
             #sometimes MeCab can't give kanji reading, and make node-feature have less than 7 when splitted.
             #bypass it and give kanji as isto avoid IndexError
-            if len(node.feature.split(",")) > 7:
-                kana = node.feature.split(",")[7] # 読み仮名を代入
+            split = node.feature.split(",")
+            if len(split) > 7:
+                kana = split[7] # 読み仮名を代入
             else:
                 kana = node.surface
             hiragana = kana2hiragana(kana)


### PR DESCRIPTION
Added support for a custom/shared mecab tagger instance. Added support for pykakasi as an alternative to jaconv. The default behavior remains unchanged.

The idea is that you can provide a mecab tagger instance. Otherwise, one is created.
The conversion from kana to hiragana is now handled through a function, allowing you to use another library for this. This is done by passing a function in which will do the conversion.